### PR TITLE
Lock Pry version and add RVMs in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: trusty
+os: linux
 branches:
   only:
     - master
@@ -6,25 +7,34 @@ language: ruby
 cache: bundler
 env:
   global:
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=12
 matrix:
   fast_finish: true
   include:
-    - ruby: 2.3
-      env:
-        - CI_NODE_INDEX=0
-    - ruby: 2.4
-      env:
-        - CI_NODE_INDEX=1
-    - ruby: 2.5
-      env:
-        - CI_NODE_INDEX=2
-    - ruby: 2.6
-      env:
-        - CI_NODE_INDEX=3
-    - ruby: 2.7
-      env:
-        - CI_NODE_INDEX=4
+    - rvm: 2.3.0
+      env: CI_NODE_INDEX=1
+    - rvm: 2.3.8
+      env: CI_NODE_INDEX=2
+    - rvm: 2.4.0
+      env: CI_NODE_INDEX=3
+    - rvm: 2.4.10
+      env: CI_NODE_INDEX=4
+    - rvm: 2.5.0
+      env: CI_NODE_INDEX=5
+    - rvm: 2.5.4
+      env: CI_NODE_INDEX=6
+    - rvm: 2.5.8
+      env: CI_NODE_INDEX=7
+    - rvm: 2.6.0
+      env: CI_NODE_INDEX=8
+    - rvm: 2.6.4
+      env: CI_NODE_INDEX=9
+    - rvm: 2.6.6
+      env: CI_NODE_INDEX=10
+    - rvm: 2.7.0
+      env: CI_NODE_INDEX=11
+    - rvm: 2.7.1
+      env: CI_NODE_INDEX=12
 before_install:
   - gem update --system
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_0.gemfile
+++ b/gemfiles/rspec_3_0.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_1.gemfile
+++ b/gemfiles/rspec_3_1.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_2.gemfile
+++ b/gemfiles/rspec_3_2.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_3.gemfile
+++ b/gemfiles/rspec_3_3.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_4.gemfile
+++ b/gemfiles/rspec_3_4.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_5.gemfile
+++ b/gemfiles/rspec_3_5.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_6.gemfile
+++ b/gemfiles/rspec_3_6.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_7.gemfile
+++ b/gemfiles/rspec_3_7.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_8.gemfile
+++ b/gemfiles/rspec_3_8.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/gemfiles/rspec_3_9.gemfile
+++ b/gemfiles/rspec_3_9.gemfile
@@ -17,8 +17,8 @@ group :documentation do
 end
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug', '~> 3.7.0'
   gem 'rake', '~> 13.0'
 end
 

--- a/rspec-tap-formatters.gemspec
+++ b/rspec-tap-formatters.gemspec
@@ -6,11 +6,14 @@ require 'rspec/tap/formatters/version'
 require 'English'
 
 Gem::Specification.new do |spec|
+  HOMEPAGE = 'https://www.github.com/avmnu-sng/rspec-tap-formatters'
+
   spec.name = 'rspec-tap-formatters'
   spec.version = RSpec::TAP::Formatters::Version::STRING
-  spec.author = 'Abhimanyu Singh'
+  spec.platform = Gem::Platform::RUBY
+  spec.authors = ['Abhimanyu Singh']
   spec.email = 'abhisinghabhimanyu@gmail.com'
-  spec.homepage = 'https://www.github.com/avmnu-sng/rspec-tap-formatters'
+  spec.homepage = HOMEPAGE
   spec.summary = 'TAP Formatters for RSpec 3'
   spec.description = <<-DESCRIPTION.gsub(/^\s+\|/, '').chomp
     |Formats RSpec-3 test report in TAP format with a proper nested display of
@@ -18,33 +21,26 @@ Gem::Specification.new do |spec|
     |failed, and pending tests per example group. It supports four different
     |TAP format styles.
   DESCRIPTION
-  spec.license = 'MIT'
 
-  spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.3.0'
-  spec.required_rubygems_version = '>= 2.0.0'
+  spec.metadata = {
+    'bug_tracker_uri' => "#{HOMEPAGE}/issues",
+    'changelog_uri' => "#{HOMEPAGE}/blob/master/CHANGELOG.md",
+    'documentation_uri' => 'https://rspec-tap-formatters.readthedocs.io/en/latest',
+    'homepage_uri' => HOMEPAGE,
+    'source_code_uri' => HOMEPAGE
+  }
 
-  spec.files = %x(
-    git ls-files -- lib/*
-  ).split($INPUT_RECORD_SEPARATOR)
+  spec.files = %x(git ls-files -- lib/*).split($INPUT_RECORD_SEPARATOR)
   spec.files += %w[CHANGELOG.md LICENSE.md README.md .yardopts .document]
-  spec.test_files = %x(
-    git ls-files -- spec/**/*_spec.rb
-  ).split($INPUT_RECORD_SEPARATOR)
+  spec.test_files = []
   spec.bindir = 'exe'
   spec.executables = []
   spec.require_path = 'lib'
 
-  spec.metadata = {
-    'homepage_uri' => 'https://www.github.com/avmnu-sng/rspec-tap-formatters',
-    'changelog_uri' => 'https://www.github.com/avmnu-sng/rspec-tap-formatters/blob/master/CHANGELOG.md',
-    'source_code_uri' => 'https://www.github.com/avmnu-sng/rspec-tap-formatters',
-    'documentation_uri' => 'https://rspec-tap-formatters.readthedocs.io/en/latest',
-    'bug_tracker_uri' => 'https://github.com/avmnu-sng/rspec-tap-formatters/issues'
-  }
+  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_rubygems_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'psych', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'rspec-core', '>= 3.0', '< 4.0'
-
   spec.add_development_dependency 'bundler', '>= 1.15.0', '< 3.0'
 end


### PR DESCRIPTION
- Locking Pry version
- Turns out that each of the builds is using ruby-2.5 to run the builds
somehow. Explicitly specifying versions now.

